### PR TITLE
Small comments suggestion..

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ZapTest.scala
+++ b/src/main/scala/uk/gov/hmrc/ZapTest.scala
@@ -24,16 +24,63 @@ import scala.Console
 import uk.gov.hmrc.utils.{InsecureClient, TestHelper}
 
 trait ZapTest extends WordSpec {
-
+  /**
+    * If, when you run the Zap tests, you find alerts that you have investigated and don't see as a problem
+    * you can filter them out by adding to this list, using the cweid and the url that the alert was found on.
+    * The CWE ID is a Common Weakness Enumeration (http://cwe.mitre.org/data/index.html), you can
+    * find this by looking at the alert output from your tests.
+    */
   val alertsToIgnore: List[ZapAlertFilter] = List.empty
+
+  /**
+    * Required field. It will rarely need to be changed. We've included it as an overridable
+    * field for flexibility and just in case.
+    */
   val zapBaseUrl: String
+
+  /**
+    * Required field. It needs to be the URL of the start page of your application (not
+    * just localhost:port).
+    */
   val testUrl: String
   lazy val theClient = new InsecureClient
+
+  /**
+    * Not a required field. This url is added as the base url to your context.
+    * A context is a construct in Zap that limits the scope of any attacks run to a
+    * particular domain (this doesn't mean that Zap won't find alerts on other services during the
+    * browser test run).
+    * This would usually be the base url of your service - eg http://localhost:xxxx.*
+    */
   val contextBaseUrl: String = ".*"
+
+  /**
+    * Not a required field. This is the url that the zap-automation library
+    * will use to filter out the alerts that are shown to you. Note that while Zap is doing
+    * testing, it is likely to find alerts from other services that you don't own - for example
+    * from logging in, therefore we recommend that you set this to be the base url for the
+    * service you are interested in.
+    */
   val alertsBaseUrl: String = ""
   var policyName: String = ""
   var context: Context = _
+
+  /**
+    * Not a required field. We recommend you don't change this field, as we've made basic choices
+    * for the platform. We made it overridable just in case your service differs from the
+    * standards of the Platform.
+    *
+    * The technologies that you put here will limit the amount of checks that ZAP will do to
+    * just the technologies that are relevant. The default technologies are set to
+    * "OS,OS.Linux,Language,Language.Xml,SCM,SCM.Git".
+    */
   val desiredTechnologyNames: String = "OS,OS.Linux,Language,Language.Xml,SCM,SCM.Git"
+
+  /**
+    * Not a required field. You may set this if you have any routes that are part of your
+    * application, but you do not want tested. For example, if you had any test-only routes, you
+    * could force Zap not to test them by adding them in here as a regex.
+    */
   val routeToBeIgnoredFromContext: String = ""
   implicit val zapAlertReads = Json.reads[ZapAlert]
   implicit val zapAlertsReads = Json.reads[ZapAlerts]


### PR DESCRIPTION
This just adds the descriptive comments from the README.md code snippet to the ZapTest's vals themselves, so they're readily to hand in IDEs when overriding.

This was born out of this [pull request review comment](https://github.tools.tax.service.gov.uk/HMRC/agent-mtd-end-to-end-tests/pull/40#discussion-diff-34432) 