### PR TITLE
PLATUI-111: Check if test URL is proxied via ZAP and fail when not proxied

### DIFF
--- a/deleteMe.sc
+++ b/deleteMe.sc
@@ -1,4 +1,0 @@
-"http://localhost:1234/abc/def".matches("http://localhost:1234/abc/def/")
-
-
-"http://localhost:1234/abc/def/".matches("http://localhost:1234/abc/def.*")

--- a/deleteMe.sc
+++ b/deleteMe.sc
@@ -1,0 +1,4 @@
+"http://localhost:1234/abc/def".matches("http://localhost:1234/abc/def/")
+
+
+"http://localhost:1234/abc/def/".matches("http://localhost:1234/abc/def.*")

--- a/src/main/scala/uk/gov/hmrc/zap/ZapException.scala
+++ b/src/main/scala/uk/gov/hmrc/zap/ZapException.scala
@@ -20,6 +20,8 @@ case class ZapException(s: String) extends Exception(s)
 
 case class SpiderScanException(message: String) extends Exception(message)
 
+case class PassiveScanException(message: String) extends Exception(message)
+
 case class ActiveScanException(message: String) extends Exception(message)
 
 case class ZapAlertException(message: String) extends Exception(message)

--- a/src/main/scala/uk/gov/hmrc/zap/ZapReport.scala
+++ b/src/main/scala/uk/gov/hmrc/zap/ZapReport.scala
@@ -23,9 +23,8 @@ import uk.gov.hmrc.zap.logger.ZapLogger._
 
 object ZapReport {
 
-  def generateHtmlReport(relevantAlerts: List[ZapAlert], failureThreshold: String, spiderScanStatus: ScanStatus,
-                         activeScanStatus: ScanStatus, missingScanners: List[Scanner], zapVersion: String): String = {
-    report.html.index(relevantAlerts, failureThreshold, spiderScanStatus, activeScanStatus, missingScanners, zapVersion).toString()
+  def generateHtmlReport(zapReport: ZapReport): String = {
+    report.html.index(zapReport).toString()
   }
 
   def writeToFile(report: String): Unit = {
@@ -40,3 +39,6 @@ object ZapReport {
     log.info(s"HTML Report generated: file://${file.getAbsolutePath}")
   }
 }
+
+case class ZapReport(relevantAlerts: List[ZapAlert], failureThreshold: String, passiveScanStatus: ScanStatus,spiderScanStatus: ScanStatus,
+                         activeScanStatus: ScanStatus, missingScanners: List[Scanner], zapVersion: String)

--- a/src/main/scala/uk/gov/hmrc/zap/ZapTest.scala
+++ b/src/main/scala/uk/gov/hmrc/zap/ZapTest.scala
@@ -64,10 +64,10 @@ trait ZapTest extends BeforeAndAfterAll with HealthCheck with ZapOrchestrator {
   private def createTestReport(): Unit = {
     lazy val zapVersion = zapSetup.findZapVersion
 
-    val zapReportInfo = ZapReport(relevantAlerts.sortBy {_.severityScore()}, zapConfiguration.failureThreshold, zapScan.passiveScanStatus,
+    val zapReport = ZapReport(relevantAlerts.sortBy {_.severityScore()}, zapConfiguration.failureThreshold, zapScan.passiveScanStatus,
       zapScan.spiderRunStatus, zapScan.activeScanStatus, zapSetup.checkMissingScanners, zapVersion)
 
-    writeToFile(generateHtmlReport(zapReportInfo))
+    writeToFile(generateHtmlReport(zapReport))
   }
 }
 

--- a/src/main/scala/uk/gov/hmrc/zap/ZapTest.scala
+++ b/src/main/scala/uk/gov/hmrc/zap/ZapTest.scala
@@ -41,8 +41,8 @@ trait ZapTest extends BeforeAndAfterAll with HealthCheck with ZapOrchestrator {
       healthCheck(zapConfiguration.testUrl)
     }
     if (zapScan.passiveScanStatus == ScanNotCompleted) {
-      throw PassiveScanException("Test URL did not proxy via ZAP. Check if the browser is configured correctly " +
-        "to proxy via ZAP.")
+      throw PassiveScanException("Test URL did not proxy via ZAP (OR) Passive Scan did not complete within configured duration." +
+        "See ERROR message in the logs above.")
     }
     zapSetup.setConnectionTimeout()
     zapSetup.checkMissingScanners

--- a/src/main/scala/uk/gov/hmrc/zap/ZapTest.scala
+++ b/src/main/scala/uk/gov/hmrc/zap/ZapTest.scala
@@ -40,6 +40,10 @@ trait ZapTest extends BeforeAndAfterAll with HealthCheck with ZapOrchestrator {
     if (zapConfiguration.debugHealthCheck) {
       healthCheck(zapConfiguration.testUrl)
     }
+    if (zapScan.passiveScanStatus == ScanNotCompleted) {
+      throw PassiveScanException("Test URL did not proxy via ZAP. Check if the browser is configured correctly " +
+        "to proxy via ZAP.")
+    }
     zapSetup.setConnectionTimeout()
     zapSetup.checkMissingScanners
     zapSetup.setUpPolicy
@@ -60,8 +64,10 @@ trait ZapTest extends BeforeAndAfterAll with HealthCheck with ZapOrchestrator {
   private def createTestReport(): Unit = {
     lazy val zapVersion = zapSetup.findZapVersion
 
-    writeToFile(generateHtmlReport(relevantAlerts.sortBy {_.severityScore()}, zapConfiguration.failureThreshold,
-      zapScan.spiderRunStatus, zapScan.activeScanStatus, zapSetup.checkMissingScanners, zapVersion))
+    val zapReportInfo = ZapReport(relevantAlerts.sortBy {_.severityScore()}, zapConfiguration.failureThreshold, zapScan.passiveScanStatus,
+      zapScan.spiderRunStatus, zapScan.activeScanStatus, zapSetup.checkMissingScanners, zapVersion)
+
+    writeToFile(generateHtmlReport(zapReportInfo))
   }
 }
 

--- a/src/main/twirl/report/index.scala.html
+++ b/src/main/twirl/report/index.scala.html
@@ -14,13 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.zap.api.ZapAlert
-@import uk.gov.hmrc.zap.api.ScanStatus
-
-@import uk.gov.hmrc.zap.api.Scanner
+@import uk.gov.hmrc.zap.ZapReport
 @import play.api.libs.json.JsValue
-@(alerts: List[ZapAlert], failureThreshold: String, spiderScanStatus: ScanStatus, activeScanStatus: ScanStatus,
-        missingScanners: List[Scanner], zapVersion: String)
+@(zapReport: ZapReport)
+
 
 <html>
     <head>
@@ -92,9 +89,9 @@
         </h1>
         <p>
         </p>
-        <h2>ZAP Version: @{zapVersion}</h2>
+        <h2>ZAP Version: @{zapReport.zapVersion}</h2>
         <div class="spacer-lg"></div>
-        @if(missingScanners.nonEmpty) {
+        @if(zapReport.missingScanners.nonEmpty) {
             <h3 id="missing-scanners-h3"> Scanners not Configured</h3>
             <table width="45%" id="missing-scanners-header" class="summary">
                 <tr bgcolor="#666666">
@@ -102,7 +99,7 @@
                     <th width="50%" align="center">Name</th>
                     <th width="25%" align="center">Scanner Type</th>
                 </tr>
-                @for(scanner <- missingScanners) {
+                @for(scanner <- zapReport.missingScanners) {
                         <tr bgcolor="#e8e8e8" type = "missing-scanners">
                             <td width="25%" height="24" align="left">@{scanner.id}</td>
                             <td width="50%" align="left">@{scanner.name}</td>
@@ -121,16 +118,16 @@
                     Level</th><th width="55%" align="center">Number of Alerts</th>
             </tr>
             <tr bgcolor="#e8e8e8">
-                <td><a href="#high">High</a></td><td id="summary-high-count" align="center">@{alerts.count {_.risk == "High"}}</td>
+                <td><a href="#high">High</a></td><td id="summary-high-count" align="center">@{zapReport.relevantAlerts.count {_.risk == "High"}}</td>
             </tr>
             <tr bgcolor="#e8e8e8">
-                <td><a href="#medium">Medium</a></td><td id="summary-medium-count" align="center">@{alerts.count {_.risk == "Medium"}}</td>
+                <td><a href="#medium">Medium</a></td><td id="summary-medium-count" align="center">@{zapReport.relevantAlerts.count {_.risk == "Medium"}}</td>
             </tr>
             <tr bgcolor="#e8e8e8">
-                <td><a href="#low">Low</a></td><td id="summary-low-count" align="center">@{alerts.count {_.risk == "Low"}}</td>
+                <td><a href="#low">Low</a></td><td id="summary-low-count" align="center">@{zapReport.relevantAlerts.count {_.risk == "Low"}}</td>
             </tr>
             <tr bgcolor="#e8e8e8">
-                <td><a href="#info">Informational</a></td><td id="summary-info-count" align="center">@{alerts.count {_.riskShortName() == "Info"}}</td>
+                <td><a href="#info">Informational</a></td><td id="summary-info-count" align="center">@{zapReport.relevantAlerts.count {_.riskShortName() == "Info"}}</td>
             </tr>
         </table>
         <div class="spacer-lg"></div>
@@ -140,20 +137,20 @@
                 <th width="45%" height="24">Scan</th><th width="55%" align="center">Status</th>
             </tr>
             <tr bgcolor="#e8e8e8">
-                <td>Passive</td><td id="passive-scan" align="center">Run</td>
+                <td>Passive</td><td id="passive-scan" align="center">@{zapReport.passiveScanStatus.toString}</td>
             </tr>
             <tr bgcolor="#e8e8e8">
-                <td>Spider</td><td id="spider-scan" align="center">@{spiderScanStatus.toString}</td>
+                <td>Spider</td><td id="spider-scan" align="center">@{zapReport.spiderScanStatus.toString}</td>
             </tr>
             <tr bgcolor="#e8e8e8">
-                <td>Active</td><td id="active-scan" align="center">@{activeScanStatus.toString}</td>
+                <td>Active</td><td id="active-scan" align="center">@{zapReport.activeScanStatus.toString}</td>
             </tr>
         </table>
         <div class="spacer-lg"></div>
-        <h3>Failure Threshold: @{failureThreshold}</h3>
+        <h3>Failure Threshold: @{zapReport.failureThreshold}</h3>
         <div class="spacer-lg"></div>
         <h3>Alert Details</h3>
-        @for(a <- alerts) {
+        @for(a <- zapReport.relevantAlerts) {
             <div class="spacer"></div>
             <table id="alert-@{a.id}" type="alert-details" result="@{a.id}" width="100%" class="results">
                 <tr height="24" class="risk-@{a.riskShortName().toLowerCase}"><a name="@{a.riskShortName().toLowerCase}"></a><th width="10%">@{a.risk} (@{a.confidence})</th>

--- a/src/test/scala/uk/gov/hmrc/ZapReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ZapReportSpec.scala
@@ -71,10 +71,10 @@ class ZapReportSpec extends BaseSpec {
       getByAtt(reportXml, "id", "summary-info-count").text shouldBe "1"
     }
 
-    "should show the correct scan status in the Summary of Scan table when spiderScan and activeScan is not completed" in new TestSetup {
+    "should show the correct scan status in the Summary of Scan table when passiveScan, spiderScan and activeScan is not completed" in new TestSetup {
       val zapReport = ZapReport(alerts,
         "AUniqueThreshold",
-        passiveScanStatus = ScanCompleted,
+        passiveScanStatus = ScanNotCompleted,
         spiderScanStatus = ScanNotCompleted,
         activeScanStatus = ScanNotCompleted,
         missingScanners,
@@ -82,12 +82,12 @@ class ZapReportSpec extends BaseSpec {
       val reportHtmlAsString: String = generateHtmlReport(zapReport)
       val reportXml: Elem = XML.loadString(reportHtmlAsString)
 
-      getByAtt(reportXml, "id", "passive-scan").text shouldBe "Run"
+      getByAtt(reportXml, "id", "passive-scan").text shouldBe "Not Run"
       getByAtt(reportXml, "id", "spider-scan").text shouldBe "Not Run"
       getByAtt(reportXml, "id", "active-scan").text shouldBe "Not Run"
     }
 
-    "should show the correct scan status in the Summary of Scan table when spiderScan and ActiveScan is completed" in new TestSetup {
+    "should show the correct scan status in the Summary of Scan table when passiveScan, spiderScan and activeScan is completed" in new TestSetup {
       val zapReport = ZapReport(alerts,
         "AUniqueThreshold",
         passiveScanStatus = ScanCompleted,

--- a/src/test/scala/uk/gov/hmrc/ZapReportSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ZapReportSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc
 
 import com.typesafe.config.{Config, ConfigFactory}
 import play.api.libs.json.{Json, Reads}
+import uk.gov.hmrc.zap.ZapReport
 import uk.gov.hmrc.zap.ZapReport._
 import uk.gov.hmrc.zap.api.{ScanCompleted, ScanNotCompleted, Scanner, ZapAlert}
 import uk.gov.hmrc.zap.client.HttpClient
@@ -41,15 +42,27 @@ class ZapReportSpec extends BaseSpec {
 
   "html report" should {
     "should contain the failure threshold " in new TestSetup {
-      val reportHtmlAsString: String = generateHtmlReport(alerts, threshold, spiderScanStatus = ScanCompleted,
-        activeScanStatus = ScanNotCompleted, missingScanners, zapVersion)
+      val zapReport = ZapReport(alerts,
+        threshold,
+        passiveScanStatus = ScanCompleted,
+        spiderScanStatus = ScanCompleted,
+        activeScanStatus = ScanNotCompleted,
+        missingScanners,
+        zapVersion)
+      val reportHtmlAsString: String = generateHtmlReport(zapReport)
 
       reportHtmlAsString should include("AUniqueThreshold")
     }
 
     "should contain the correct alert count by risk in the Summary of Alerts table" in new TestSetup {
-      val reportHtmlAsString: String = generateHtmlReport(alerts, "AUniqueThreshold",
-        spiderScanStatus = ScanCompleted, activeScanStatus = ScanNotCompleted, missingScanners, zapVersion)
+      val zapReport = ZapReport(alerts,
+        "AUniqueThreshold",
+        passiveScanStatus = ScanCompleted,
+        spiderScanStatus = ScanCompleted,
+        activeScanStatus = ScanNotCompleted,
+        missingScanners,
+        zapVersion)
+      val reportHtmlAsString: String = generateHtmlReport(zapReport)
       val reportXml: Elem = XML.loadString(reportHtmlAsString)
 
       getByAtt(reportXml, "id", "summary-high-count").text shouldBe "1"
@@ -59,8 +72,14 @@ class ZapReportSpec extends BaseSpec {
     }
 
     "should show the correct scan status in the Summary of Scan table when spiderScan and activeScan is not completed" in new TestSetup {
-      val reportHtmlAsString: String = generateHtmlReport(alerts, "AUniqueThreshold",
-        spiderScanStatus = ScanNotCompleted, activeScanStatus = ScanNotCompleted, missingScanners, zapVersion)
+      val zapReport = ZapReport(alerts,
+        "AUniqueThreshold",
+        passiveScanStatus = ScanCompleted,
+        spiderScanStatus = ScanNotCompleted,
+        activeScanStatus = ScanNotCompleted,
+        missingScanners,
+        zapVersion)
+      val reportHtmlAsString: String = generateHtmlReport(zapReport)
       val reportXml: Elem = XML.loadString(reportHtmlAsString)
 
       getByAtt(reportXml, "id", "passive-scan").text shouldBe "Run"
@@ -69,8 +88,14 @@ class ZapReportSpec extends BaseSpec {
     }
 
     "should show the correct scan status in the Summary of Scan table when spiderScan and ActiveScan is completed" in new TestSetup {
-      val reportHtmlAsString: String = generateHtmlReport(alerts, "AUniqueThreshold",
-        spiderScanStatus = ScanCompleted, activeScanStatus = ScanCompleted, missingScanners, zapVersion)
+      val zapReport = ZapReport(alerts,
+        "AUniqueThreshold",
+        passiveScanStatus = ScanCompleted,
+        spiderScanStatus = ScanCompleted,
+        activeScanStatus = ScanCompleted,
+        missingScanners,
+        zapVersion)
+      val reportHtmlAsString: String = generateHtmlReport(zapReport)
       val reportXml: Elem = XML.loadString(reportHtmlAsString)
 
       getByAtt(reportXml, "id", "passive-scan").text shouldBe "Run"
@@ -79,8 +104,14 @@ class ZapReportSpec extends BaseSpec {
     }
 
     "should display the details of 4 alerts" in new TestSetup {
-      val reportHtmlAsString: String = generateHtmlReport(alerts, "AUniqueThreshold",
-        spiderScanStatus = ScanCompleted, activeScanStatus = ScanCompleted, missingScanners, zapVersion)
+      val zapReport = ZapReport(alerts,
+        "AUniqueThreshold",
+        passiveScanStatus = ScanCompleted,
+        spiderScanStatus = ScanCompleted,
+        activeScanStatus = ScanCompleted,
+        missingScanners,
+        zapVersion)
+      val reportHtmlAsString: String = generateHtmlReport(zapReport)
       val reportXml: Elem = XML.loadString(reportHtmlAsString)
 
       getByAtt(reportXml, "type", "alert-details").size shouldBe 4
@@ -90,8 +121,14 @@ class ZapReportSpec extends BaseSpec {
       override val missingScanners: List[Scanner] =
         List(Scanner("9999", "TestScanner1", "Passive Scan"), Scanner("10000", "TestScanner2", "Passive Scan"))
 
-      val reportHtmlAsString: String = generateHtmlReport(alerts, "AUniqueThreshold",
-        spiderScanStatus = ScanCompleted, activeScanStatus = ScanCompleted, missingScanners, zapVersion)
+      val zapReport = ZapReport(alerts,
+        "AUniqueThreshold",
+        passiveScanStatus = ScanCompleted,
+        spiderScanStatus = ScanCompleted,
+        activeScanStatus = ScanCompleted,
+        missingScanners,
+        zapVersion)
+      val reportHtmlAsString: String = generateHtmlReport(zapReport)
       val reportXml: Elem = XML.loadString(reportHtmlAsString)
 
       getByAtt(reportXml, "id", "missing-scanners-h3").size shouldBe 1
@@ -100,8 +137,14 @@ class ZapReportSpec extends BaseSpec {
     }
 
     "should not display missing scanners list when all required scanners configured" in new TestSetup {
-      val reportHtmlAsString: String = generateHtmlReport(alerts, "AUniqueThreshold",
-        spiderScanStatus = ScanCompleted, activeScanStatus = ScanCompleted, missingScanners, zapVersion)
+      val zapReport = ZapReport(alerts,
+        "AUniqueThreshold",
+        passiveScanStatus = ScanCompleted,
+        spiderScanStatus = ScanCompleted,
+        activeScanStatus = ScanCompleted,
+        missingScanners,
+        zapVersion)
+      val reportHtmlAsString: String = generateHtmlReport(zapReport)
       val reportXml: Elem = XML.loadString(reportHtmlAsString)
 
       getByAtt(reportXml, "type", "missing-scanners").size shouldBe 0
@@ -110,8 +153,14 @@ class ZapReportSpec extends BaseSpec {
     }
 
     "should contain ZAP version" in new TestSetup {
-      val reportHtmlAsString: String = generateHtmlReport(alerts, threshold, spiderScanStatus = ScanCompleted,
-        activeScanStatus = ScanNotCompleted, missingScanners, zapVersion)
+      val zapReport = ZapReport(alerts,
+        threshold,
+        passiveScanStatus = ScanCompleted,
+        spiderScanStatus = ScanCompleted,
+        activeScanStatus = ScanNotCompleted,
+        missingScanners,
+        zapVersion)
+      val reportHtmlAsString: String = generateHtmlReport(zapReport)
 
       reportHtmlAsString should include(s"ZAP Version: $zapVersion")
     }


### PR DESCRIPTION
- The new isUrlProxiedViaZap() checks if the test url patter is proxied via ZAP. Test URL is a mandatory field in zap-automation-config, so teams will always provide this. 
- If test URL is not proxied, then Passive Scan in the HTML report is set to 'Not Run' and the test is failed without continuing further. 
- Refactored HTML report generator to take ZapReport object instead of individual arguments. 